### PR TITLE
Fix bug in Global Search where matching part is not correctly highlighted in Left Panel.

### DIFF
--- a/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
@@ -219,19 +219,17 @@ class FourByteClpIrStreamReader {
         const contentUint8Array = outputResizableBuffer.getUint8Array();
         const contentString = FourByteClpIrStreamReader.textDecoder.decode(contentUint8Array);
 
-        let contentLowerCaseString = contentString;
-        let searchLowerCaseString = searchString;
-        if (matchCase === false) {
-            contentLowerCaseString = contentLowerCaseString.toLowerCase();
-            searchLowerCaseString = searchString.toLowerCase();
+        let regexPattern = searchString;
+        let regexFlags = "";
+        if (!isRegex) {
+            regexPattern = searchString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        }
+        if (!matchCase) {
+            regexFlags = "i";
         }
 
-        let match;
-        if (isRegex) {
-            match = contentLowerCaseString.match(searchString);
-        } else if (contentLowerCaseString.includes(searchLowerCaseString)) {
-            match = searchString;
-        }
+        const searchRegex = new RegExp(regexPattern, regexFlags);
+        const match = contentString.match(searchRegex);
 
         return {match, contentString};
     }


### PR DESCRIPTION
# References
Found bug in Global Search where matching part is not correctly highlighted in Left Panel.
![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/75155116-b341-40a6-b46c-fd8daf7071e3)

# Description
1. Fix bug in Global Search where matching part is not correctly highlighted in Left Panel.

# Validation performed
1. Loaded `https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst`.
2. Performed search with keyword `rmc` and setting `matchCase=false; isRegex=false`, and observed below matching lines are found, and the matching parts are correctly highlighted:

   ![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/9b361d40-87b0-43a4-8f4a-bec8aae130e3)

   ```
   2015-03-23T09:26:28.536Z INFO org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager: ContainerTokenKeyRollingInterval: 86400000ms and ContainerTokenKeyActivationDelay: 900000ms
   2015-03-23T09:26:31.405Z INFO org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager: Rolling master-key for container-tokens
   2015-03-23T09:37:09.850Z INFO org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl: container_1427088391284_0001_01_000001 Container Transitioned from NEW to ALLOCATED
   ... 997 more Log Events
   ```
4. Performed search with keyword `rmc` and setting `matchCase=true; isRegex=false`, and the returned results do not include the first two ones shown above.
   
   ![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/668a4797-a5c4-4838-8f57-7a497729944c)

5. Performed search with keyword `r.c` and setting `matchCase=false; isRegex=true`, and the returned results included more than the ones with "RMC..." label:

   ![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/64c29ef3-caaf-4c73-afc4-3b8db66e1a15)

6. Performed search with keyword `r.c` and setting `matchCase=true; isRegex=true`, and the returned results included more than the ones with "RMC..." label and cases do match:
   
   ![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/6dd34ea5-0baa-4e4d-9d0a-654f3d6cfd63)

## Performance Before
![image](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/1a6f5407-a3a0-415d-8032-327d8d04468c)

## Performance with the Changes
3287 ms improvement for searching an IR Stream with 375558 log events!

![1706635656097](https://github.com/jackluo923/yscope-log-viewer/assets/43196707/52f15a09-241b-4269-8744-32e3b8f0355c)

