### PR TITLE
Refactor worker Global Search code.

### DIFF
--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -668,6 +668,13 @@ class FileManager {
         this._updateLogsCallback(this._logs);
     };
 
+    /**
+     * Searches log events for a specified string or regular expression.
+     *
+     * @param {string} searchString string or regular expression to search for
+     * @param {boolean} isRegex whether the search string is regular expression
+     * @param {boolean} matchCase whether the search should be case-sensitive
+     */
     searchLogEvents = (searchString, isRegex, matchCase) => {
         // increment job id for every new query
         //  so the last job can be interrupted by itself checking
@@ -707,9 +714,18 @@ class FileManager {
             resultsOnCurrPage: [],
             resultsByPages: [],
         };
+
         this._searchChunk(searchState, 0);
     };
 
+    /**
+     * Searches for log events within a specified range and updates the search
+     * state.
+     *
+     * @param {Object} searchState including search settings and results.
+     * @param {number} logEventsBeginIdx first log event to search from
+     * @private
+     */
     _searchChunk (searchState, logEventsBeginIdx) {
         const numEventsAtLevel = this._logEventOffsetsFiltered.length;
 
@@ -746,7 +762,7 @@ class FileManager {
 
             if (eventIdx + 1 === searchState.pageEndEventIdx) {
                 // To update progress, always send searchResults
-                //  even if it is empty
+                // even if it is empty
                 searchState.resultsByPages.push({
                     pageIdx: searchState.currPageIdx,
                     results: structuredClone(searchState.resultsOnCurrPage),
@@ -780,6 +796,13 @@ class FileManager {
         }, 0);
     }
 
+    /**
+     * Retrieves the log content from a specified log event index.
+     *
+     * @param {number} eventIdx of the log event to retrieve content from
+     * @return {string} the log content as a string
+     * @private
+     */
     _getLogContentFromEventIdx (eventIdx) {
         const event = this._logEventOffsetsFiltered[eventIdx];
         this._irStreamReader._dataInputStream.seek(event.startIndex);
@@ -792,6 +815,14 @@ class FileManager {
         );
     }
 
+    /**
+     * Sends search results for processed log pages and continues searching the
+     * next chunk if needed.
+     *
+     * @param {Object} searchState including search settings and results.
+     * @param {number} logEventsBeginIdx first log event to search from
+     * @private
+     */
     _sendSearchResultsAndSearchNextChunk (searchState, logEventsBeginIdx) {
         let lastEmptyResultPageIdx = null;
 

--- a/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
@@ -219,19 +219,17 @@ class FourByteClpIrStreamReader {
         const contentUint8Array = outputResizableBuffer.getUint8Array();
         const contentString = FourByteClpIrStreamReader.textDecoder.decode(contentUint8Array);
 
-        let contentLowerCaseString = contentString;
-        let searchLowerCaseString = searchString;
-        if (matchCase === false) {
-            contentLowerCaseString = contentLowerCaseString.toLowerCase();
-            searchLowerCaseString = searchString.toLowerCase();
+        let regexPattern = searchString;
+        let regexFlags = "";
+        if (!isRegex) {
+            regexPattern = searchString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        }
+        if (!matchCase) {
+            regexFlags = "i";
         }
 
-        let match;
-        if (isRegex) {
-            match = contentLowerCaseString.match(searchString);
-        } else if (contentLowerCaseString.includes(searchLowerCaseString)) {
-            match = searchString;
-        }
+        const searchRegex = new RegExp(regexPattern, regexFlags);
+        const match = contentString.match(searchRegex);
 
         return {match, contentString};
     }

--- a/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
@@ -152,6 +152,19 @@ class FourByteClpIrStreamReader {
         return true;
     }
 
+    /**
+     * Reads and decodes a log event into the provided output resizable buffer.
+     *
+     * @param {ResizableUint8Array} outputResizableBuffer where the decoded log
+     * event will be stored.
+     * @return {Object} An object containing information about the decoded log
+     * event:
+     *   - {number} verbosityIx of the log event
+     *   - {number} beginOffset of the WHOLE log event output
+     *   in outputResizableBuffer
+     *   - {number} contentBeginOffset of the log event output
+     *   in outputResizableBuffer
+     */
     readAndDecodeLogEventIntoBuffer (outputResizableBuffer) {
         let timestamp = null;
         let verbosityIx = null;


### PR DESCRIPTION
# References
Refactor worker Global Search code to prepare support for searching log files other than CLP IR Stream. 

# Description
1. Refactor worker Global Search code.

# Validation performed
1. Loaded https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst.
2. Toggle Search panel from the left Navigation Bar. Type query `1234` one-character-by-another (1-2-3-4) and observed search results to show up but getting cleared as the query string changes.
3. Pressed `Backspace` to delete character `4` from the query string and observed results matching `123` to show up. In the results, string `123` are correctly highlighted, and clicking on the results navigates the editor to the correct log event line. 
