### PR TITLE
Support downloading decompressed Single-file CLP, zst, zip, tar.gz, gz, gzip archives

### DIFF
--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -9,13 +9,10 @@ import {
     ChevronRight,
     FileText,
     Keyboard,
-    Moon,
-    Sun
 } from "react-bootstrap-icons";
 
 import {THEME_STATES} from "../../../ThemeContext/THEME_STATES";
 import {ThemeContext} from "../../../ThemeContext/ThemeContext";
-import LOCAL_STORAGE_KEYS from "../../services/LOCAL_STORAGE_KEYS";
 import MODIFY_PAGE_ACTION from "../../services/MODIFY_PAGE_ACTION";
 import STATE_CHANGE_TYPE from "../../services/STATE_CHANGE_TYPE";
 import {EditableInput} from "./EditableInput/EditableInput";
@@ -47,21 +44,14 @@ MenuBar.propTypes = {
  * @return {JSX.Element}
  */
 export function MenuBar ({
-    logFileState, fileInfo, loadingLogs, changeStateCallback, loadFileCallback,
+    logFileState, fileInfo, loadingLogs, changeStateCallback,
 }) {
-    const {theme, switchTheme} = useContext(ThemeContext);
+    const {theme} = useContext(ThemeContext);
 
-    const [eventsPerPage, setEventsPerPage] = useState(logFileState.pages);
-    const [showSettings, setShowSettings] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
-
-    const handleCloseSettings = () => setShowSettings(false);
-    const handleShowSettings = () => setShowSettings(true);
 
     const handleCloseHelp = () => setShowHelp(false);
     const handleShowHelp = () => setShowHelp(true);
-
-    const downloadWorker = useRef(null);
 
     const goToFirstPage = () => {
         if (logFileState.page !== 1) {
@@ -93,38 +83,6 @@ export function MenuBar ({
     // Modal Functions
     const getModalClass = () => {
         return (THEME_STATES.LIGHT === theme)?"modal-light":"modal-dark";
-    };
-
-    const saveModalChanges = (e) => {
-        // TODO Can't backspace 0 from the number input
-        // TODO What is the maximum number of events monaco can support?
-        e.preventDefault();
-        handleCloseSettings();
-        changeStateCallback(STATE_CHANGE_TYPE.pageSize, {pageSize: eventsPerPage});
-        localStorage.setItem(LOCAL_STORAGE_KEYS.PAGE_SIZE, String(eventsPerPage));
-    };
-
-    const closeModal = () => {
-        handleCloseSettings();
-    };
-
-    const openModal = () => {
-        handleShowSettings();
-        setEventsPerPage(logFileState.pageSize);
-    };
-
-    const getThemeIcon = () => {
-        if (THEME_STATES.LIGHT === theme) {
-            return (
-                <Moon className="cursor-pointer" title="Set Light Mode"
-                    onClick={() => switchTheme(THEME_STATES.DARK)}/>
-            );
-        } else if (THEME_STATES.DARK === theme) {
-            return (
-                <Sun className="cursor-pointer" title="Set Dark Mode"
-                    onClick={() => switchTheme(THEME_STATES.LIGHT)}/>
-            );
-        }
     };
 
     const getPageNav = () => {
@@ -160,7 +118,6 @@ export function MenuBar ({
     };
 
     const fileName = fileInfo.name.split("?")[0];
-
     // TODO make file icon a button to open modal with file info
     // TODO Move modals into their own component
     return (
@@ -185,35 +142,6 @@ export function MenuBar ({
                 </div>
                 {getLoadingBar()}
             </div>
-            <Modal show={showSettings} className="border-0" onHide={handleCloseSettings}
-                contentClassName={getModalClass()}>
-                <Modal.Header className="modal-background border-0" >
-                    <div className="float-left">
-                        App Settings
-                    </div>
-                    <div className="float-right">
-                        {getThemeIcon()}
-                    </div>
-                </Modal.Header>
-                <Modal.Body className="modal-background p-3 pt-1" >
-                    <label className="mb-2">Log Events per Page</label>
-                    <Form onSubmit={saveModalChanges}>
-                        <Form.Control type="number"
-                            value={eventsPerPage}
-                            onChange={(e) => setEventsPerPage(Number(e.target.value))}
-                            className="input-sm num-event-input" />
-                    </Form>
-                </Modal.Body>
-                <Modal.Footer className="modal-background border-0" >
-                    <Button className="btn-sm" variant="success" onClick={saveModalChanges}>
-                        Save Changes
-                    </Button>
-                    <Button className="btn-sm" variant="secondary" onClick={closeModal}>
-                        Close
-                    </Button>
-                </Modal.Footer>
-            </Modal>
-
             <Modal show={showHelp} className="help-modal border-0" onHide={handleCloseHelp}
                 contentClassName={getModalClass()} data-theme={theme}>
                 <Modal.Header className="modal-background" >

--- a/src/Viewer/services/WorkerPool.js
+++ b/src/Viewer/services/WorkerPool.js
@@ -54,7 +54,12 @@ class WorkerPool {
             const worker = this.getWorker();
             if (worker) {
                 const task = this.taskQueue.shift();
-                worker.postMessage(task, [task.inputStream]);
+                if (null === task.pageLogs) {
+                    worker.postMessage(task, [task.inputStream]);
+                } else {
+                    // FIXME: dirty hack to get download working
+                    worker.postMessage(task);
+                }
                 worker.onmessage = () => {
                     this.freeWorker(worker);
                     this.processQueue();

--- a/src/Viewer/services/decoder/decodeWorker.js
+++ b/src/Viewer/services/decoder/decodeWorker.js
@@ -3,38 +3,42 @@ import {DataInputStream, DataInputStreamEOFError} from "./DataInputStream";
 import FourByteClpIrStreamReader from "./FourByteClpIrStreamReader";
 import ResizableUint8Array from "./ResizableUint8Array";
 
-const decodePage = async (fileName, logEvents, inputStream, page) => {
-    const dataInputStream = new DataInputStream(inputStream);
-    const _outputResizableBuffer = new ResizableUint8Array(inputStream.byteLength);
-    const _irStreamReader = new FourByteClpIrStreamReader(dataInputStream, null);
+const decodePage = async (fileName, logEvents, inputStream, page, pageLogs) => {
+    let _logs = pageLogs;
 
-    const _logEventMetadata = [];
-    for (let i = 0; i < logEvents.length; i++) {
-        const decoder = _irStreamReader._streamProtocolDecoder;
-        decoder._setTimestamp(logEvents[i].prevTs);
+    if (null === _logs) {
+        const dataInputStream = new DataInputStream(inputStream);
+        const _outputResizableBuffer = new ResizableUint8Array(inputStream.byteLength);
+        const _irStreamReader = new FourByteClpIrStreamReader(dataInputStream, null);
 
-        try {
-            _irStreamReader.readAndDecodeLogEvent(
-                _outputResizableBuffer,
-                _logEventMetadata
-            );
-        } catch (error) {
+        const _logEventMetadata = [];
+        for (let i = 0; i < logEvents.length; i++) {
+            const decoder = _irStreamReader._streamProtocolDecoder;
+            decoder._setTimestamp(logEvents[i].prevTs);
+
+            try {
+                _irStreamReader.readAndDecodeLogEvent(
+                    _outputResizableBuffer,
+                    _logEventMetadata
+                );
+            } catch (error) {
             // Ignore EOF errors since we should still be able
             // to print the decoded messages
-            if (error instanceof DataInputStreamEOFError) {
+                if (error instanceof DataInputStreamEOFError) {
                 // TODO Give visual indication that the stream is truncated
-                console.error("Stream truncated.");
-            } else {
-                console.log("random error");
-                throw error;
+                    console.error("Stream truncated.");
+                } else {
+                    console.log("random error");
+                    throw error;
+                }
             }
         }
-    }
 
-    // Decode the text
-    const _textDecoder = new TextDecoder();
-    const logs = _textDecoder.decode(_outputResizableBuffer.getUint8Array());
-    const _logs = logs.trim();
+        // Decode the text
+        const _textDecoder = new TextDecoder();
+        const logs = _textDecoder.decode(_outputResizableBuffer.getUint8Array());
+        _logs = logs.trim();
+    }
 
     const db = new Database(fileName);
     db.addPage(page, _logs).then(() => {
@@ -51,5 +55,6 @@ onmessage = (e) => {
     const logEvents = e.data.logEvents;
     const inputStream = e.data.inputStream;
     const page = e.data.page;
-    decodePage(fileName, logEvents, inputStream, page);
+    const pageLogs = e.data.pageLogs;
+    decodePage(fileName, logEvents, inputStream, page, pageLogs);
 };


### PR DESCRIPTION
# Description
1. Support downloading decompressed Single-file CLP, zst, zip, tar.gz, gz, gzip archives.
2. Fix a bug where compressed file size was displayed as uncompressed file size. 

# Validation performed
1. Tested the log viewer with the following log files on public S3 bucket as well as open them locally via drag and drop. 
2. Tested pagination and global search as well. 
3. Tested "Download Uncompressed" as well. 

- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/zip-archive.zip
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt.zst
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt.gz
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt
- https://<local.server>/tar-gz-archive.tar.gz (https://yscope.s3.us-east-2.amazonaws.com/sample-logs/tar-gz-archive.tar.gz with first hidden file removed.)