### PR TITLE
Fix a bug where partial log content is not shown when there are multiple matching parts; Change progress bar color to green once search is completed.

### DIFF
--- a/src/Viewer/components/SearchPanel/SearchPanel.js
+++ b/src/Viewer/components/SearchPanel/SearchPanel.js
@@ -139,6 +139,7 @@ export function SearchPanel ({
                 </form>
                 {(progress !== null) &&
                     <ProgressBar animated={progress !== 100} now={progress}
+                        variant={progress === 100?"success":undefined}
                         style={{height: "3px"}}/>}
             </div>
             <div className={"search-results-container"}>
@@ -198,7 +199,10 @@ function SearchResultsGroup ({
     }, [collapseAll]);
 
     const resultsRows = results.searchResults.map((result) => {
-        const [prefix, postfix] = result["content"].split(result["match"]);
+        const split = result["content"].split(result["match"]);
+        const prefix = split[0];
+        const postfix = split.slice(1).join("");
+
         return (
             <button
                 className={"search-result-button"}


### PR DESCRIPTION
# References
1. In Global Search panel, when there are multiple matching parts in the content string, the substring after the matching highlighted keyword is partially displayed. e.g. When searching with keyword `2`, content `2024-02-01` would only be shown as `20` in the Global Search panel. 
2. Displaying a full progress bar when a Global Search finishes could be confusing as the stopped animation is not sufficient to indicate the search is complete. Instead, set progress bar color to green once progress reaches 100%. 

# Description
1. Fix a bug where partial log content is not shown when there are multiple matching parts
2. Change progress bar color to green once search is completed.

# Validation performed
1. Loaded https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst.
2. Toggle Search panel from the left Navigation Bar.
3. Type query 1234 one-character-by-another (1-2-3-4) and observed search results to show up but getting cleared as the query string changes. **Because there is no log content matching `1234` the progress bar gradually grew and became full. The color of the progress bar changed to green once it was full.** 
4. Pressed Backspace to delete character 4 from the query string and observed results matching 123 to show up. In the results, string 123 are correctly highlighted, and clicking on the results navigates the editor to the correct log event line.
