### PR TITLE
Disable verbosity change for formats Single-file CLP, zst, zip, tar.gz, gz, gzip.

### DIFF
--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -25,7 +25,7 @@ class ActionHandler {
         this._logFile = new FileManager(fileSrc, prettify, logEventIdx, initialTimestamp, pageSize,
             this._loadingMessageCallback, this._updateStateCallback, this._updateLogsCallback,
             this._updateFileInfoCallback, this._updateSearchResultsCallback);
-                this._logFile.loadLogFile().then(()=> {
+        this._logFile.loadLogFile().then(()=> {
             console.log(fileSrc, "File loaded successfully");
         }).catch((e) => {
             this._loadingMessageCallback(e, true);
@@ -40,6 +40,13 @@ class ActionHandler {
     changeVerbosity (desiredVerbosity) {
         if (!isNumeric(desiredVerbosity)) {
             throw (new Error("Invalid verbosity provided."));
+        }
+        if (null !== this._logFile._logsArray) {
+            // FIXME: dirty hack
+            this._logFile.verbosity = -1;
+            this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._logFile.state);
+
+            return;
         }
         this._logFile.state.verbosity = desiredVerbosity;
         this._logFile.filterLogEvents(desiredVerbosity);


### PR DESCRIPTION
# References
There is no known universal schema to parse verbosity from the log lines. Brainstorming is required for a generic solution. Before that, disable verbosity change for formats Single-file CLP, zst, zip, tar.gz, gz, gzip.
# Description
1. Disable verbosity change for formats Single-file CLP, zst, zip, tar.gz, gz, gzip.

# Validation performed
1. Loaded example.clp Single-file CLP archive.
2. Changed verbosity in the Status Bar to "ERROR' and observed no change in page size. 
