### PR TITLE
Support PC browser zoom by mousewheel & mobile browser zoom by pinch.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="description" content="CLP Log Viewer">
     <meta name="keywords" content="clp debug debugging large log logs s3 scanner viewer vscode">
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1">
 </head>
 <body>
     <div id="app"></div>


### PR DESCRIPTION
# Description
1. Support PC browser zoom by mouse wheel.
2. Support mobile browser zoom by pinch.

# Validation performed
1. Loaded example log file in PC browser. Held down `Ctrl` on the keyboard and scroll up / down to zoom in / out in the Log Viewer.
2. Loaded example log file in Android browser. Pinched in / out to zoom in / out in the Log Viewer.
