### PR TITLE
Add getAbsoluteUrl function to convert relative paths into absolute ones.

### DIFF
--- a/src/Viewer/components/LeftPanel/DownloadHelper.js
+++ b/src/Viewer/components/LeftPanel/DownloadHelper.js
@@ -1,4 +1,8 @@
-import {getFilePathFromWindowLocation} from "../../services/utils";
+import {
+    getAbsoluteUrl,
+    getFilePathFromWindowLocation,
+} from "../../services/utils";
+
 
 const downloadBlob = (blob, databaseName) => {
     const blobUrl = URL.createObjectURL(blob);
@@ -26,16 +30,7 @@ const downloadCompressedFile = () => {
     link.target = "_blank";
 
     const filePath = getFilePathFromWindowLocation();
-    try {
-        // this URL constructor should only succeed if "filePath"
-        //  has a "protocol" scheme like "http:"
-        new URL(filePath);
-        link.href = filePath;
-    } catch (e) {
-        link.href = window.location.origin + "/" + filePath;
-    }
-
-    console.log(link);
+    link.href = getAbsoluteUrl(filePath);
     link.click();
 };
 

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -44,15 +44,41 @@ const modifyPage = (action, currentPage, requestedPage, pages) => {
 };
 
 /**
+ * Returns the absolute URL of a given path relative to the window.location,
+ * if the given path is a relative one.
+ *
+ * @param {string} path that is either absolute or relative
+ * @returns {string}
+ */
+const getAbsoluteUrl = (path) => {
+    try {
+        // This URL() constructor should only succeed if `path`
+        //  has a "protocol" scheme like "http:"
+        // eslint-disable-next-line no-new
+        new URL(path);
+    } catch (e) {
+        path = new URL(path, window.location.origin).href;
+    }
+
+    return path;
+};
+
+/**
  * Parses `filePath` from the current window location's search query.
  *
  * @return {string|null} The parsed file path or
  *                       null if not found.
  */
 const getFilePathFromWindowLocation = () => {
-    const filePath = window.location.search.split("filePath=")[1];
+    let filePath = window.location.search.split("filePath=")[1];
 
-    return (undefined === filePath) ? null : filePath.substring(filePath.indexOf("#"));
+    if (undefined === filePath) {
+        return null;
+    }
+
+    filePath = filePath.substring(filePath.indexOf("#"));
+
+    return getAbsoluteUrl(filePath);
 };
 
 /**
@@ -78,6 +104,7 @@ const getModifiedUrl = (searchParams, hashParams) => {
         if ("filePath" === key) {
             // to be appended as the last parameter
             filePath = value;
+            urlSearchParams.delete(key);
         } else if (null === value) {
             urlSearchParams.delete(key);
         } else {
@@ -172,4 +199,11 @@ function binarySearchWithTimestamp (timestamp, logEventMetadata) {
     return null;
 }
 
-export {binarySearchWithTimestamp, getFilePathFromWindowLocation, getModifiedUrl, isNumeric, modifyPage};
+export {
+    binarySearchWithTimestamp,
+    getAbsoluteUrl,
+    getFilePathFromWindowLocation,
+    getModifiedUrl,
+    isNumeric,
+    modifyPage,
+};


### PR DESCRIPTION
# References
Internally it was discovered that loading the Log Viewer with a relative path fails, because the FileManager was unable to construct an URL object with a path that does not contain an protocol (e.g. `http://` scheme:
https://github.com/jackluo923/yscope-log-viewer/blob/0d414eceddc0108492682fbacc8a19e63c7d69de/src/Viewer/services/decoder/FileManager.js#L325

e.g. those link fails to load the `filePath` log files,
1. `http://localhost:3010/?filePath=/test.clp.zst`
2. `http://localhost:3010/?filePath=test.clp.zst`
# Description
1. Add getAbsoluteUrl function to convert relative paths into absolute ones.

# Validation performed
1. Built and visited the links mentioned in the above "References" section. 
2. Observed the Log Viewer loaded the log files without any errors. 
3. Observed in the browser address bar the relative paths are converted into full paths.
4. Validated log event "Copy" button and the generated link correctly navigated to the desired log event location. 