### PR TITLE
Calendar overflow

### DIFF
--- a/src/Viewer/components/modals/CalendarModal/DatetimePicker.jsx
+++ b/src/Viewer/components/modals/CalendarModal/DatetimePicker.jsx
@@ -44,9 +44,15 @@ const DateTimePicker = ({onChange, value}) => {
                 <DateCalendar
                     {...commonProps}
                     sx={{
-                        height: "300px",
-                        minWidth: "260px",
-                        borderRight: "1px solid rgba(0, 0, 0, 0.2)",
+                        ".MuiMonthCalendar-root": {
+                            width: "100%",
+                        },
+                        ".MuiYearCalendar-root": {
+                            width: "100%",
+                        },
+                        "borderRight": "1px solid rgba(0, 0, 0, 0.2)",
+                        "height": "320px",
+                        "minWidth": "260px",
                     }}
                     views={[
                         "year",
@@ -60,7 +66,7 @@ const DateTimePicker = ({onChange, value}) => {
                     timeSteps={{hours: 1, minutes: 1, seconds: 1}}
                     sx={{
                         ".MuiMultiSectionDigitalClockSection-root": {
-                            maxHeight: "300px",
+                            maxHeight: "320px",
                             width: "72px",
                         },
                         "borderBottom": "0",


### PR DESCRIPTION
# References
Internally it was discovered that the Month and Year selector in the DatetimePicker overflows and are partially visible.
 
# Description
1. Fix width and height of DateCalendar's Month & Year selectors to avoid hidden overflow.

# Validation performed
1. Validated manually. 
