### PR TITLE
Add `...` for truncated search log lines.

### DIFF
--- a/src/Viewer/components/SearchPanel/SearchPanel.js
+++ b/src/Viewer/components/SearchPanel/SearchPanel.js
@@ -213,7 +213,7 @@ function SearchResultsGroup ({
             >
                 {/* Cap prefix length to be 25 characters
                      so highlighted text can be shown */}
-                <span>{prefix.slice(-25)}</span>
+                <span>{(25 < prefix.length) && "..."}{prefix.slice(-25)}</span>
                 <span
                     className={"search-result-highlight"}>{result["match"]}</span>
                 <span>{postfix}</span>


### PR DESCRIPTION
# References
In the search results previews, currently we do not have visual indicators to show if the log line has been truncated from the beginning. 

# Description
2. Add `...` for truncated search log lines to avoid confusions.

# Validation performed
1. Validated manually.
