### PR TITLE
Show warning if there are more search results than `FILE_MANAGER_LOG_SEARCH_MAX_RESULTS=1000`.

### DIFF
--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -316,6 +316,7 @@ export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
                     ...prevArray,
                     {
                         page_num: event.data.page_num,
+                        hasMoreResults: event.data.hasMoreResults,
                         searchResults: event.data.searchResults,
                     },
                 ]);

--- a/src/Viewer/components/SearchPanel/SearchPanel.js
+++ b/src/Viewer/components/SearchPanel/SearchPanel.js
@@ -7,7 +7,8 @@ import {
     ArrowsExpand,
     CaretDownFill,
     CaretRightFill,
-    Regex
+    ExclamationTriangle,
+    Regex,
 } from "react-bootstrap-icons";
 
 import "./SearchPanel.scss";
@@ -79,20 +80,21 @@ export function SearchPanel ({
 
     let resultGroups = <></>;
     let progress = null;
-    if (searchResults !== null) {
+    let hasMoreResults = false;
+    if (null !== searchResults) {
         resultGroups = searchResults.map((resultGroup, index) => (
             <SearchResultsGroup
                 key={index}
                 pageNum={resultGroup.page_num}
                 results={resultGroup}
                 collapseAll={collapseAll}
-                setCollapseAll={setCollapseAll}
                 resultClickHandler={searchResultClickHandler}
             />
         ));
         if (searchResults.length) {
             progress = (searchResults[searchResults.length - 1].page_num + 1) /
                 totalPages * 100;
+            hasMoreResults = searchResults[searchResults.length - 1].hasMoreResults;
         } else {
             // instead of 0 set progress as 5% to show something is being loaded
             progress = 5;
@@ -143,6 +145,15 @@ export function SearchPanel ({
                         style={{height: "3px"}}/>}
             </div>
             <div className={"search-results-container"}>
+                {hasMoreResults &&
+                <div>
+                    <ExclamationTriangle size={14} color={"#FFBF00"}/>
+                    &nbsp;
+                    <span>
+                        The result set only contains a subset of all matches.
+                        Be more specific in your search to narrow down the results.
+                    </span>
+                </div>}
                 {resultGroups}
             </div>
         </>
@@ -174,7 +185,6 @@ SearchResultsGroup.propTypes = {
  * @param {number} pageNum
  * @param {object} results
  * @param {boolean} collapseAll
- * @param {SetCollapseAll} setCollapseAll
  * @param {ResultClickHandler} resultClickHandler
  * @return {JSX.Element}
  */
@@ -182,7 +192,6 @@ function SearchResultsGroup ({
     pageNum,
     results,
     collapseAll,
-    setCollapseAll,
     resultClickHandler,
 }) {
     if (results.searchResults.length === 0) {

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -270,10 +270,11 @@ class ActionHandler {
         });
     };
 
-    _updateSearchResultsCallback = (i, searchResults) => {
+    _updateSearchResultsCallback = (i, hasMoreResults, searchResults) => {
         postMessage({
             code: CLP_WORKER_PROTOCOL.UPDATE_SEARCH_RESULTS,
             page_num: i,
+            hasMoreResults: hasMoreResults,
             searchResults: searchResults,
         });
     };

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -710,6 +710,7 @@ class FileManager {
 
         const searchState = {
             isSearching: true,
+            hasMoreResults: false,
             searchRegex: searchRegex,
             numTotalResults: 0,
             currPageIdx: 0,
@@ -749,12 +750,14 @@ class FileManager {
                 });
                 searchState.numTotalResults++;
 
-                if (FILE_MANAGER_LOG_SEARCH_MAX_RESULTS <= searchState.numTotalResults) {
+                if (FILE_MANAGER_LOG_SEARCH_MAX_RESULTS < searchState.numTotalResults) {
                     searchState.isSearching = false;
+                    searchState.hasMoreResults = true;
                     searchState.resultsByPages.push({
                         pageIdx: searchState.currPageIdx,
-                        results: structuredClone(searchState.resultsOnCurrPage),
+                        results: structuredClone(searchState.resultsOnCurrPage.slice(0, -1)),
                     });
+
                     searchState.resultsByPages.push({
                         pageIdx: this.state.pages - 1,
                         results: [],
@@ -840,14 +843,26 @@ class FileManager {
                 lastEmptyResultPageIdx = r.pageIdx;
             } else {
                 if (lastEmptyResultPageIdx !== null) {
-                    this._updateSearchResultsCallback(lastEmptyResultPageIdx, []);
+                    this._updateSearchResultsCallback(
+                        lastEmptyResultPageIdx,
+                        searchState.hasMoreResults,
+                        [],
+                    );
                     lastEmptyResultPageIdx = null;
                 }
-                this._updateSearchResultsCallback(r.pageIdx, r.results);
+                this._updateSearchResultsCallback(
+                    r.pageIdx,
+                    searchState.hasMoreResults,
+                    r.results,
+                );
             }
         });
         if (lastEmptyResultPageIdx !== null) {
-            this._updateSearchResultsCallback(lastEmptyResultPageIdx, []);
+            this._updateSearchResultsCallback(
+                lastEmptyResultPageIdx,
+                searchState.hasMoreResults,
+                [],
+            );
         }
 
         searchState.resultsByPages.length = 0;


### PR DESCRIPTION
# References
For application stability, we currently do not search beyond 1000 results. However, we do not notify users if there could be more results beyond this limit.

# Description
1. Show warning if there are more search results than `FILE_MANAGER_LOG_SEARCH_MAX_RESULTS=1000`.

# Validation performed
1. Validated manually.