### PR TITLE
Move sessionId to sessionStorage

### DIFF
--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -4,6 +4,7 @@ import React, {
 } from "react";
 import {Row} from "react-bootstrap";
 import LoadingIcons from "react-loading-icons";
+import {v1 as uuidv1} from "uuid";
 
 import {THEME_STATES} from "../ThemeContext/THEME_STATES";
 import {ThemeContext} from "../ThemeContext/ThemeContext";
@@ -126,8 +127,11 @@ export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
             Number(timestamp) :
             null;
 
+        const sessionId = uuidv1();
+        window.sessionStorage.setItem("sessionId", sessionId);
         clpWorker.current.postMessage({
             code: CLP_WORKER_PROTOCOL.LOAD_FILE,
+            sessionId: sessionId,
             fileSrc: fileSrc,
             prettify: logFileState.prettify,
             logEventIdx: logEvent,

--- a/src/Viewer/components/LeftPanel/LeftPanel.js
+++ b/src/Viewer/components/LeftPanel/LeftPanel.js
@@ -255,7 +255,7 @@ function LeftPanelTabs ({
 
         worker.postMessage({
             code: DOWNLOAD_WORKER_ACTION.initialize,
-            sessionID: fileInfo.sessionID,
+            sessionId: window.sessionStorage.getItem("sessionId"),
             count: logFileState.downloadPageChunks,
         });
 

--- a/src/Viewer/components/LeftPanel/downloadWorker.js
+++ b/src/Viewer/components/LeftPanel/downloadWorker.js
@@ -38,7 +38,7 @@ onmessage = function (e) {
 
     switch (msg.code) {
         case DOWNLOAD_WORKER_ACTION.initialize:
-            db = new Database(e.data.sessionID);
+            db = new Database(e.data.sessionId);
             totalCount = e.data.count;
             isDecodingDone();
             break;

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -24,9 +24,10 @@ class ActionHandler {
      * @param {Number} initialTimestamp
      * @param {Number} pageSize
      */
-    constructor (fileSrc, prettify, logEventIdx, initialTimestamp, pageSize) {
+    constructor (fileSrc, sessionId, prettify, logEventIdx, initialTimestamp, pageSize) {
         this._logFile = new FileManager(
             fileSrc,
+            sessionId,
             prettify,
             logEventIdx,
             initialTimestamp,

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -20,12 +20,14 @@ onmessage = function (e) {
         case CLP_WORKER_PROTOCOL.LOAD_FILE:
             try {
                 const {fileSrc} = e.data;
+                const {sessionId} = e.data;
                 const {prettify} = e.data;
                 const {logEventIdx} = e.data;
                 const {pageSize} = e.data;
                 const {initialTimestamp} = e.data;
                 handler = new ActionHandler(
                     fileSrc,
+                    sessionId,
                     prettify,
                     logEventIdx,
                     initialTimestamp,

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -1,7 +1,6 @@
 import {Tarball} from "@obsidize/tar-browserify";
 import JSZip from "jszip";
 import pako from "pako";
-import {v1 as uuidv1} from "uuid";
 
 import {ZstdCodec} from "../../../../customized-packages/zstd-codec/js";
 import CLP_WORKER_PROTOCOL from "../CLP_WORKER_PROTOCOL";
@@ -47,7 +46,7 @@ class FileManager {
      * @param {function} updateFileInfoCallback
      * @param {function} updateSearchResultsCallback
      */
-    constructor (fileSrc, prettify, logEventIdx, initialTimestamp, pageSize,
+    constructor (fileSrc, sessionId, prettify, logEventIdx, initialTimestamp, pageSize,
         loadingMessageCallback,
         updateStateCallback, updateLogsCallback, updateFileInfoCallback,
         updateSearchResultsCallback) {
@@ -68,22 +67,6 @@ class FileManager {
         this._fileInfo = {
             name: null,
             path: null,
-            sessionID: null,
-        };
-
-        this.state = {
-            pageSize: pageSize,
-            pages: null,
-            page: null,
-            prettify: prettify,
-            logEventIdx: logEventIdx,
-            lineNumber: null,
-            columnNumber: null,
-            numberOfEvents: null,
-            verbosity: null,
-            compressedHumanSize: null,
-            decompressedHumanSize: null,
-            downloadChunkSize: 10000,
         };
 
         this._logs = "";
@@ -109,6 +92,23 @@ class FileManager {
         this._logSearchJobId = 0;
 
         this._workerPool = new WorkerPool();
+
+        this.state = {
+            pageSize: pageSize,
+            pages: null,
+            page: null,
+            prettify: prettify,
+            logEventIdx: logEventIdx,
+            lineNumber: null,
+            columnNumber: null,
+            numberOfEvents: null,
+            verbosity: null,
+            compressedHumanSize: null,
+            decompressedHumanSize: null,
+            downloadChunkSize: 10000,
+        };
+
+        this.sessionId = sessionId;
     }
 
 
@@ -234,7 +234,6 @@ class FileManager {
      */
     _updateInputFileInfo (file) {
         this._fileInfo = file;
-        this._fileInfo.sessionID = uuidv1();
         this._updateFileInfoCallback(this._fileInfo);
 
         this.state.compressedHumanSize = formatSizeInBytes(file.data.byteLength, false);
@@ -543,9 +542,9 @@ class FileManager {
         if (null !== this._logsArray) {
             // FIXME: dirty hack to get download working
             this._workerPool.assignTask({
-                sessionID: this._fileInfo.sessionID,
+                sessionID: this.sessionId,
                 page: page,
-                pageLogs:
+                f:
                     this._logsArray?.slice(targetEvent, targetEvent + numberOfEvents).join("\n"),
             });
             return;
@@ -559,7 +558,7 @@ class FileManager {
         const logEvents = this._logEventOffsets.slice(targetEvent, targetEvent + numberOfEvents );
 
         this._workerPool.assignTask({
-            sessionID: this._fileInfo.sessionID,
+            sessionID: this.sessionId,
             page: page,
             logEvents: logEvents,
             inputStream: inputStream,

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -542,7 +542,7 @@ class FileManager {
         if (null !== this._logsArray) {
             // FIXME: dirty hack to get download working
             this._workerPool.assignTask({
-                sessionID: this.sessionId,
+                sessionId: this.sessionId,
                 page: page,
                 f:
                     this._logsArray?.slice(targetEvent, targetEvent + numberOfEvents).join("\n"),
@@ -558,7 +558,7 @@ class FileManager {
         const logEvents = this._logEventOffsets.slice(targetEvent, targetEvent + numberOfEvents );
 
         this._workerPool.assignTask({
-            sessionID: this.sessionId,
+            sessionId: this.sessionId,
             page: page,
             logEvents: logEvents,
             inputStream: inputStream,

--- a/src/Viewer/services/decoder/decodeWorker.js
+++ b/src/Viewer/services/decoder/decodeWorker.js
@@ -3,7 +3,7 @@ import {DataInputStream, DataInputStreamEOFError} from "./DataInputStream";
 import FourByteClpIrStreamReader from "./FourByteClpIrStreamReader";
 import ResizableUint8Array from "./ResizableUint8Array";
 
-const decodePage = async (sessionID, logEvents, inputStream, page, pageLogs) => {
+const decodePage = async (sessionId, logEvents, inputStream, page, pageLogs) => {
     let _logs = pageLogs;
 
     if (null === _logs) {
@@ -40,7 +40,7 @@ const decodePage = async (sessionID, logEvents, inputStream, page, pageLogs) => 
         _logs = logs.trim();
     }
 
-    const db = new Database(sessionID);
+    const db = new Database(sessionId);
     db.addPage(page, _logs).then(() => {
         console.debug(`Finished decoding page ${page} to database.`);
         postMessage(true);
@@ -51,10 +51,10 @@ const decodePage = async (sessionID, logEvents, inputStream, page, pageLogs) => 
 };
 
 onmessage = (e) => {
-    const sessionID = e.data.sessionID;
+    const sessionId = e.data.sessionId;
     const logEvents = e.data.logEvents;
     const inputStream = e.data.inputStream;
     const page = e.data.page;
     const pageLogs = e.data.pageLogs;
-    decodePage(sessionID, logEvents, inputStream, page, pageLogs);
+    decodePage(sessionId, logEvents, inputStream, page, pageLogs);
 };


### PR DESCRIPTION
# References
#11 @junhaoliao suggests storing `sessionId` in `sessionStorage`, which avoids passing it everywhere though `fileInfo`.

# Description
Generate `sessionId` in `Viewer`, which are then passed to `clpWorker`, `ActionHandler` and eventually to `FileManager`. Meanwhile, store `sessionId` in `sessionStorage` in `Viewer.js`, which are later used in `LeftPanel.js`.

# Validation performed
Open log viewer in two tabs, download two files with the same name but different content in parallel. Note that no data races happened during the download.

