### PR TITLE
Correct `postfix` reconstruction in search result renderings.

### DIFF
--- a/src/Viewer/components/SearchPanel/SearchPanel.js
+++ b/src/Viewer/components/SearchPanel/SearchPanel.js
@@ -207,24 +207,25 @@ function SearchResultsGroup ({
         setCollapsed(collapseAll);
     }, [collapseAll]);
 
-    const resultsRows = results.searchResults.map((result) => {
-        const split = result["content"].split(result["match"]);
-        const prefix = split[0];
-        const postfix = split.slice(1).join("");
+    const resultsRows = results.searchResults.map((r) => {
+        const {content, eventIndex, match} = r;
+        const split = content.split(match);
+        const [prefix] = split;
+        const postfix = split.slice(1).join(match);
 
         return (
             <button
                 className={"search-result-button"}
-                key={result.eventIndex}
+                key={eventIndex}
                 onClick={() => {
-                    resultClickHandler(result.eventIndex + 1);
+                    resultClickHandler(eventIndex + 1);
                 }}
             >
                 {/* Cap prefix length to be 25 characters
                      so highlighted text can be shown */}
                 <span>{(25 < prefix.length) && "..."}{prefix.slice(-25)}</span>
                 <span
-                    className={"search-result-highlight"}>{result["match"]}</span>
+                    className={"search-result-highlight"}>{match}</span>
                 <span>{postfix}</span>
             </button>
         );


### PR DESCRIPTION
# References
Internally it was discovered that in the search result panel, result previews are not rendered correctly when there are more than one occurrences of the matching keyword. The matching keyword only appears once in the result previews and any occurrences after are missing. 
# Description
1. Correct `postfix` reconstruction in search result renderings by joining the right splits with the matching keyword.

# Validation performed
1. Opened the Log Viewer with example log file: http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventIdx=375558 .
2. Searched with search string `2` and observed in the result previews, all timestamps are correctly presented: e.g., **2**015-03-**2**3T09:**2**6:06.**2**58Z.
