### PR TITLE
Add support for prettifying CLP Single Archive logs.

### DIFF
--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -577,17 +577,22 @@ class FileManager {
                 this._logsArray.length,
                 this.state.pageSize * (this.state.page));
 
-            let offset = 0;
+            this.state.logEventIdx = startingEventIdx;
             this._logsPageLineOffsetsArray.length = 0;
             this._logs = "";
 
-            for (let i = startingEventIdx; i< endingEventIdx; i++) {
-                this._logs += this._logsArray[i] + "\n";
+            let offset = 0;
+            for (let i = startingEventIdx; i < endingEventIdx; i++) {
+                this._logs += this.state.prettify ?
+                    this._prettifier.prettify(this._logsArray[i])[1] :
+                    this._logsArray[i];
+                this._logs += "\n";
                 this._logsPageLineOffsetsArray.push(offset);
                 offset += this._logsArray[i].split("\n").length;
             }
 
             this._updateLogsCallback(this._logs);
+
             return;
         }
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = mergeWithRules({
     },
 })(common, {
     mode: "development",
-    devtool: "cheap-module-source-map",
+    devtool: "eval-source-map",
     devServer: {
         hot: true,
         port: 3010,


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
1. [Add support for prettifying CLP Single Archive logs.](https://github.com/jackluo923/yscope-log-viewer/commit/2b8d8fdb01c6c1e23803b09f511d1f8febf1ed92)
2. [Update devtool option in webpack dev configuration to enhance debug capability.](https://github.com/jackluo923/yscope-log-viewer/commit/9c975590475fcc3293923aa1d3a7a07de45e656f)
   e.g., in exception stack trace, show source code's files and lines instead of bundled js's files and lines.

# Validation performed
<!-- What tests and validation you performed on the change -->

