### PR TITLE
Fix download uncompressed: either not downloading or only contains "undefined" in the result file.

### DIFF
--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -6,6 +6,8 @@ import {Row} from "react-bootstrap";
 import LoadingIcons from "react-loading-icons";
 
 import dayjs from "dayjs";
+import tz from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import {v1 as uuidv1} from "uuid";
 
 import {THEME_STATES} from "../ThemeContext/THEME_STATES";
@@ -30,6 +32,9 @@ import {
 
 import "./Viewer.scss";
 
+
+dayjs.extend(utc);
+dayjs.extend(tz);
 
 Viewer.propTypes = {
     fileSrc: oneOfType([

--- a/src/Viewer/services/decoder/ClpArchiveDecoder.js
+++ b/src/Viewer/services/decoder/ClpArchiveDecoder.js
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import initSqlJs from "sql.js";
 import {XzReadableStream} from "xzwasm";
 
@@ -8,6 +9,8 @@ import {
     DataInputStream, DataInputStreamEOFError,
 } from "./DataInputStream";
 
+
+dayjs.extend(utc);
 
 /**
  *

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -544,7 +544,7 @@ class FileManager {
             this._workerPool.assignTask({
                 sessionId: this.sessionId,
                 page: page,
-                f:
+                pageLogs:
                     this._logsArray?.slice(targetEvent, targetEvent + numberOfEvents).join("\n"),
             });
             return;

--- a/src/Viewer/services/decoder/IRTokenDecoder.js
+++ b/src/Viewer/services/decoder/IRTokenDecoder.js
@@ -1,8 +1,13 @@
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import tz from "dayjs/plugin/timezone";
 
 import LogtypeBuf from "./LogtypeBuf";
 import PROTOCOL from "./PROTOCOL";
 
+
+dayjs.extend(utc);
+dayjs.extend(tz);
 
 class IRTokenDecoder {
     constructor () {


### PR DESCRIPTION
# References
1. Download uncompressed clp archive file bug: download gives undefined;
2. Download uncompressed zst bug: doesn't initiate downloading at all.

# Description
For 1, edit the `f` to `pageLogs` in `FileManager.js`.
For 2, let `dayjs` extend the utc & timezone plugins.

# Validation performed
1. Start log viewer, load clp archive file, download uncompressed & gives out actual logs.
2. load a standard zst file, vice versa.
